### PR TITLE
Revert to previous formula, keep 3.57.6

### DIFF
--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -7,31 +7,21 @@ class Mod < Formula
   license :public_domain
 
   stable do
-    url Stable::URL, using: :nounzip
+    url Stable::URL
     sha256 Stable::SHA256
     version Stable::VERSION
   end
 
   head do
-    url Staging::URL, using: :nounzip
+    url Staging::URL
     sha256 Staging::SHA256
     version Staging::VERSION
   end
 
   def install
-    # The .sh file is a self-extracting archive (shell header + tgz after __ARCHIVE__ marker)
-    system "sh", "-c",
-           "tail -n+$(awk '/^__ARCHIVE__$/{print NR+1;exit}' \"$1\") \"$1\" | tar xzf -",
-           "--", cached_download
-    libexec.install Dir["*"]
-    bin.install_symlink libexec/"modw"
-    bin.install_symlink bin/"modw" => "mod"
-
-    # Trigger AOT cache creation
-    system "#{bin}/mod", "--version"
+    bin.install "mod"
   end
-
   test do
-    system "#{bin}/mod", "--version"
-  end
+      system "#{bin}/mod"
+   end
 end

--- a/Formula/stable.rb
+++ b/Formula/stable.rb
@@ -1,5 +1,5 @@
 module Stable
-  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.6/moderne-cli-macos.sh"
+  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.6/moderne-cli-macos.tar.gz"
   SHA256 = "d5e8ad19e2385ae1a8b3062591a981582f65acae293d15b38a55ad57bda5db63"
   VERSION = "v3.57.6"
 end


### PR DESCRIPTION
**What**:
Partially reverts https://github.com/moderneinc/homebrew-moderne/commit/b2258b508b172d718d0f8492ea4fe4247561af82
Revert to the previous formula, before the no-native-builds changes.
But keep the 3.57.6 as current stable.

**Why**:
People observe:
```
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "mod (v3.57.6)"
Download failed: https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.6/moderne-cli-macos.sh
```
while installing Moderne CLI via homebrew.