### PR TITLE
Revert mod formula to serve the 3.x CLI line

### DIFF
--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -1,17 +1,28 @@
+require_relative "stable"
+require_relative "staging"
+
 class Mod < Formula
   desc "Automated code remediation."
   homepage "https://moderne.io"
   license :public_domain
-  url "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.0/moderne-cli-4.0.0-modw.sh"
-  sha256 ""
-  version "4.0.0"
+
+  stable do
+    url Stable::URL
+    sha256 Stable::SHA256
+    version Stable::VERSION
+  end
+
+  head do
+    url Staging::URL
+    sha256 Staging::SHA256
+    version Staging::VERSION
+  end
 
   def install
-    bin.install "moderne-cli-#{version}-modw.sh" => "modw"
-    bin.install_symlink bin/"modw" => "mod"
+    bin.install "mod"
   end
 
   test do
-    system "#{bin}/mod", "--version"
+    system "#{bin}/mod"
   end
 end


### PR DESCRIPTION
## Summary
- Reverts `mod.rb` from the 4.0.0 modw wrapper format back to the modular formula that references `stable.rb` and `staging.rb`
- Both `stable.rb` and `staging.rb` already point to v3.57.12, so `brew install moderneinc/moderne/mod` will install the latest 3.x release
- The 4.0.0 release workflow overwrote `mod.rb` with a template that pointed at a Maven Central URL for a modw.sh that doesn't exist yet

## Test plan
- [ ] `brew install moderneinc/moderne/mod` installs v3.57.12
- [ ] `mod --version` reports 3.57.12