### PR TITLE
Revert "Update mod to 4.0.4"

### DIFF
--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -22,6 +22,6 @@ class Mod < Formula
     bin.install "mod"
   end
   test do
-      system "#{bin}/mod"
+      system "#{bin}/mod", "--version"
    end
 end

--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -19,7 +19,12 @@ class Mod < Formula
   end
 
   def install
-    bin.install "mod"
+    if head?
+      bin.install "moderne-cli-#{version}-modw.sh" => "modw"
+      bin.install_symlink bin/"modw" => "mod"
+    else
+      bin.install "mod"
+    end
   end
   test do
       system "#{bin}/mod", "--version"

--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -1,17 +1,27 @@
+require_relative "stable"
+require_relative "staging"
+
 class Mod < Formula
   desc "Automated code remediation."
   homepage "https://moderne.io"
   license :public_domain
-  url "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.4/moderne-cli-4.0.4-modw.sh"
-  sha256 "d40133a075d66dae16b5d0e0af46f3ac2594b1ed063406322185a39d449633dd"
-  version "4.0.4"
+
+  stable do
+    url Stable::URL
+    sha256 Stable::SHA256
+    version Stable::VERSION
+  end
+
+  head do
+    url Staging::URL
+    sha256 Staging::SHA256
+    version Staging::VERSION
+  end
 
   def install
-    bin.install "moderne-cli-#{version}-modw.sh" => "modw"
-    bin.install_symlink bin/"modw" => "mod"
+    bin.install "mod"
   end
-
   test do
-    system "#{bin}/mod", "--version"
-  end
+      system "#{bin}/mod"
+   end
 end

--- a/Formula/stable.rb
+++ b/Formula/stable.rb
@@ -1,5 +1,5 @@
 module Stable
-  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.12/moderne-cli-macos.tar.gz"
-  SHA256 = "a9e461b18494cd5a2083fee8b1562156254034d86f444b231f2c416c17f0e0ee"
-  VERSION = "v3.57.12"
+  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.14/moderne-cli-macos.tar.gz"
+  SHA256 = "6afac583b5203e4c601fefc7e74d13e9f75660fa446eba9f9c96cd096e128ba2"
+  VERSION = "v3.57.14"
 end

--- a/Formula/staging.rb
+++ b/Formula/staging.rb
@@ -1,5 +1,5 @@
 module Staging
-  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.14/moderne-cli-macos.tar.gz"
-  SHA256 = "6afac583b5203e4c601fefc7e74d13e9f75660fa446eba9f9c96cd096e128ba2"
-  VERSION = "v3.57.14"
+  URL = "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.4/moderne-cli-4.0.4-modw.sh"
+  SHA256 = "d40133a075d66dae16b5d0e0af46f3ac2594b1ed063406322185a39d449633dd"
+  VERSION = "4.0.4"
 end


### PR DESCRIPTION
This reverts commit 9786f9f4490c6c2e9598bc7405ecee1f56a443c0.

**What**:
Reverts the commit marking 4.0.4 as the only CLI version.

Keeps 4.0.4 as the staging version (with its new way of installing stuff).

**Why**:
3.57.14 is the current stable.

**Testing performed**:
Symlinked this code to /opt/homebrew/Library/Taps/
and ran `brew install` and `brew install --HEAD` against this and observed 3.57.14 and 4.0.4 installed properly.
Both of them start fine.