### PR TITLE
Staging 4.0.5, while stable is kept at 3.57.14

### DIFF
--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -1,17 +1,32 @@
+require_relative "stable"
+require_relative "staging"
+
 class Mod < Formula
   desc "Automated code remediation."
   homepage "https://moderne.io"
   license :public_domain
-  url "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.5/moderne-cli-4.0.5-modw.sh"
-  sha256 "0ac0cfca4fd792cc6838609de91e5b4f0bd983001cc13ebd9c1e8267bff34938"
-  version "4.0.5"
+
+  stable do
+    url Stable::URL
+    sha256 Stable::SHA256
+    version Stable::VERSION
+  end
+
+  head do
+    url Staging::URL
+    sha256 Staging::SHA256
+    version Staging::VERSION
+  end
 
   def install
-    bin.install "moderne-cli-#{version}-modw.sh" => "modw"
-    bin.install_symlink bin/"modw" => "mod"
+    if head?
+      bin.install "moderne-cli-#{version}-modw.sh" => "modw"
+      bin.install_symlink bin/"modw" => "mod"
+    else
+      bin.install "mod"
+    end
   end
-
   test do
-    system "#{bin}/mod", "--version"
-  end
+      system "#{bin}/mod", "--version"
+   end
 end

--- a/Formula/staging.rb
+++ b/Formula/staging.rb
@@ -1,5 +1,5 @@
 module Staging
-  URL = "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.4/moderne-cli-4.0.4-modw.sh"
-  SHA256 = "d40133a075d66dae16b5d0e0af46f3ac2594b1ed063406322185a39d449633dd"
-  VERSION = "4.0.4"
+  URL = "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.5/moderne-cli-4.0.5-modw.sh"
+  SHA256 = "0ac0cfca4fd792cc6838609de91e5b4f0bd983001cc13ebd9c1e8267bff34938"
+  VERSION = "4.0.5"
 end


### PR DESCRIPTION
- Similar to #6, making sure that:
- 4.0.5 is marked as current staging
- 3.57.14 is kept as stable
- honoring both have different ways of installing
