### PR TITLE
3.57.16 as stable, 4.0.5 as staging

### DIFF
--- a/Formula/mod.rb
+++ b/Formula/mod.rb
@@ -19,9 +19,14 @@ class Mod < Formula
   end
 
   def install
-    bin.install "mod"
+    if head?
+      bin.install "moderne-cli-#{version}-modw.sh" => "modw"
+      bin.install_symlink bin/"modw" => "mod"
+    else
+      bin.install "mod"
+    end
   end
   test do
-      system "#{bin}/mod"
+      system "#{bin}/mod", "--version"
    end
 end

--- a/Formula/staging.rb
+++ b/Formula/staging.rb
@@ -1,5 +1,5 @@
 module Staging
-  URL = "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.5/moderne-cli-4.0.5-modw.sh"
-  SHA256 = "0ac0cfca4fd792cc6838609de91e5b4f0bd983001cc13ebd9c1e8267bff34938"
-  VERSION = "4.0.5"
+  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.16/moderne-cli-macos.tar.gz"
+  SHA256 = "37bc754890ee341e8f7bce039214494cf99485cd4d1fa515075e7b7db0994bec"
+  VERSION = "v3.57.16"
 end

--- a/Formula/staging.rb
+++ b/Formula/staging.rb
@@ -1,5 +1,5 @@
 module Staging
-  URL = "https://github.com/moderneinc/moderne-cli-releases/releases/download/v3.57.16/moderne-cli-macos.tar.gz"
-  SHA256 = "37bc754890ee341e8f7bce039214494cf99485cd4d1fa515075e7b7db0994bec"
-  VERSION = "v3.57.16"
+  URL = "https://repo1.maven.org/maven2/io/moderne/moderne-cli/4.0.5/moderne-cli-4.0.5-modw.sh"
+  SHA256 = "0ac0cfca4fd792cc6838609de91e5b4f0bd983001cc13ebd9c1e8267bff34938"
+  VERSION = "4.0.5"
 end


### PR DESCRIPTION
- Similar to #7, making sure that:
- 4.0.5 is marked as current staging
- 3.57.16 is marked as stable
- honoring both have different ways of installing
